### PR TITLE
Add hyperlink fields to alert for operational runbooks

### DIFF
--- a/public/config.json.example
+++ b/public/config.json.example
@@ -1,1 +1,18 @@
-{"endpoint": "http://localhost:8080"}
+{
+  "endpoint": "http://localhost:8080",
+  "runbook": [
+    {
+      "output": "<a href=https://link-to-correct-resource.com>handbook1</a>",
+      "matches": [
+        {
+          "column": "event",
+          "regex": "http.*"
+        },
+        {
+          "column": "Environment",
+          "regex": "^Dev.*$"
+        }
+      ]
+    }
+  ]
+}

--- a/src/components/AlertList.vue
+++ b/src/components/AlertList.vue
@@ -85,6 +85,19 @@
             >
               {{ props.item.event }}
             </span>
+
+            <!-- Additional column for operational runbook links -->
+            <span
+              v-if="col == 'info'"
+            >
+              <div
+                v-for="data in $config.runbook"
+                :key="data.output"
+              >                
+                <div v-html="findMatch(data,props)" />
+              </div>
+            </span>
+            
             <span
               v-if="col == 'environment'"
             >
@@ -497,6 +510,7 @@ export default {
       id: { text: i18n.t('AlertId'), value: 'id' },
       resource: { text: i18n.t('Resource'), value: 'resource' },
       event: { text: i18n.t('Event'), value: 'event' },
+      info: { text: i18n.t('Info'), value: 'info', sortable: false },
       environment: { text: i18n.t('Environment'), value: 'environment' },
       severity: { text: i18n.t('Severity'), value: 'severity' },
       correlate: { text: i18n.t('Correlate'), value: 'correlate' },
@@ -549,8 +563,9 @@ export default {
     },
     columnWidths() {
       return {
-        '--value-width': this.valueWidth() + 'px',
-        '--text-width': this.textWidth() + 'px'
+        // '--value-width': this.valueWidth() + 'px',
+        // '--text-width': this.textWidth() + 'px'
+        // altered to prevent overflow and odd spacing in last column
       }
     },
     isLoading() {
@@ -635,7 +650,19 @@ export default {
   created() {
     this.initHotkeys()
   },
-  methods: {
+  methods: {   
+    // method for mapping table data to links from runbook data
+    findMatch(additionalRespObj, props){   
+      const validMatch = additionalRespObj.matches.every(matchesObj => {
+        // make comparisons case-insensitive
+        const filter = new RegExp((matchesObj.regex).toLowerCase())
+        const columnName = (matchesObj.column).toLowerCase()
+        const columnData = (props.item[columnName]).toLowerCase()
+        return filter.test(columnData)
+      })
+      // return link if all regex checks pass
+      return validMatch ? additionalRespObj.output : null 
+    },
     initHotkeys() {
       window.addEventListener('keydown', this.processHotkey)
       window.addEventListener('keyup', this.removeHotkey)
@@ -848,7 +875,7 @@ div.select-box {
 }
 
 div.action-buttons {
-  position: absolute;
+  position: relative;
   opacity: 0;
   right: 0;
   top: 0.5em;

--- a/src/locales/de.js
+++ b/src/locales/de.js
@@ -92,6 +92,7 @@ export const de = {
   Environment: 'Umgebung',
   Resource: 'Ressource',
   Event: 'Ereignis',
+  Info: 'die Info',
   Correlate: 'Korrelation',
   Group: 'Gruppe',
   Severity: 'Schweregrad',

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -92,6 +92,7 @@ export const en = {
   Environment: 'Environment',
   Resource: 'Resource',
   Event: 'Event',
+  Info: 'Info',
   Correlate: 'Correlate',
   Group: 'Group',
   Severity: 'Severity',

--- a/src/locales/fr.js
+++ b/src/locales/fr.js
@@ -70,7 +70,7 @@ export const fr = {
   Unshelve: 'Unshelve',
   Close: 'Close', //'Fermé',
   Watch: 'Watch', //'Surveiller',
-  Notes: 'Notes', // 'Remarques'
+  Notes: 'Remarques', // 'Remarques'
   Unwatch: 'Unwatch', //'Ne plus surveiller',
   AddNote: 'Add note', //'Ajouter Note',
   Delete: 'Delete', //'Supprimer',

--- a/src/locales/fr.js
+++ b/src/locales/fr.js
@@ -92,6 +92,7 @@ export const fr = {
   Environment: 'Environnement',
   Resource: 'Ressource',
   Event: 'Evénement',
+  Info: 'Info',
   Correlate: 'Corrélation',
   Group: 'Groupe',
   Severity: 'Gravité',

--- a/src/locales/tr.js
+++ b/src/locales/tr.js
@@ -93,6 +93,7 @@ export const tr = {
   Environment: 'Ortam',
   Resource: 'Kaynak',
   Event: 'Olay',
+  Info: 'Bilgi',
   Correlate: 'İlişkilendir',
   Group: 'Grup',
   Severity: 'Şiddet',

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -34,6 +34,14 @@ class Config {
         console.log(error)
         throw error
       })
+      .then(config => {
+        if ('columns' in config) {
+          if (config.hasOwnProperty('runbook')) {
+            config.columns.push('info')
+          }
+        }
+        return config
+      })
   }
 
   getEnvConfig() {


### PR DESCRIPTION
This change introduces the runbook configuration option in config.json. The runbook output is displayed in the alerta data table when the regex for the alert metadata is matched.

"runbook": [
    {
      "output": "<a href=https://link-to-correct-resource.com>handbook1</a>",
      "matches": [
        {
          "column": "event",
          "regex": "http.*"
        },
        {
          "column": "Environment",
          "regex": "^Dev.*$"
        }
      ]
    }
  ],

Both single and multiple-column matching is supported.