### PR TITLE
Optional filtered alerts count based on status

### DIFF
--- a/public/config.json.example
+++ b/public/config.json.example
@@ -1,6 +1,7 @@
 {
   "endpoint": "http://localhost:8080",
   "statusCounts": ["open", "ack"],
+  "notificationBlackout": true,
   "runbook": [
     {
       "output": "<a href=https://link-to-correct-resource.com>handbook1</a>",

--- a/public/config.json.example
+++ b/public/config.json.example
@@ -1,5 +1,6 @@
 {
   "endpoint": "http://localhost:8080",
+  "statusCounts": ["open", "ack"],
   "runbook": [
     {
       "output": "<a href=https://link-to-correct-resource.com>handbook1</a>",

--- a/public/config.json.example
+++ b/public/config.json.example
@@ -1,7 +1,6 @@
 {
   "endpoint": "http://localhost:8080",
-  "statusCounts": ["open", "ack"],
-  "notificationBlackout": true,
+  "countsFilter": "open",
   "runbook": [
     {
       "output": "<a href=https://link-to-correct-resource.com>handbook1</a>",

--- a/src/components/AlertIndicator.vue
+++ b/src/components/AlertIndicator.vue
@@ -115,58 +115,66 @@ export default {
     severityColor(severity) {
       return this.counts && this.counts[severity] ? this.$store.getters.getConfig('colors').severity[severity] : 'transparent'
     },
+    async getCountsOfStatus(status) {
+      // build the query for this status
+      let searchParams = null
+      // depending on the type of query, build the search params
+      if (Array.isArray(this.query)) {
+        searchParams = new URLSearchParams([...this.query, ['status', status]])
+      } else {
+        let queryStr = this.query.toString()
+        if (typeof this.query === 'object') {
+          queryStr = this.query.q.replace(':', '=')
+        }
+        searchParams = new URLSearchParams(`${queryStr}&status=${status}`)
+      }
 
+      // get the counts for this status
+      const response = await AlertsApi.getCounts(searchParams)
+      return response.severityCounts
+    },
     async getCounts() {
-      const statusOfCounts = this.$store.getters.getConfig('statusCounts')
-      if (statusOfCounts) {
-        // first get the total counts.
-        const response = await AlertsApi.getCounts(new URLSearchParams(this.query))
-        let totalCounts = response.severityCounts
-        // create a count holder object
+      const notificationBlackoutConfig = this.$store.getters.getConfig('notificationBlackout')
+      const blackoutCounts = notificationBlackoutConfig ? await this.getCountsOfStatus('blackout') : null
+      const statusCountsConfig = this.$store.getters.getConfig('statusCounts')
+      // first get the total counts.
+      const response = await AlertsApi.getCounts(new URLSearchParams(this.query))
+      const totalCounts = response.severityCounts
+      // if there are blackout counts, remove them from the total counts
+      if (blackoutCounts) {
+        for (let key in blackoutCounts) {
+          totalCounts[key] -= blackoutCounts[key]
+        }
+      }
+      if (statusCountsConfig) {
+        // create a count holder object. Named to not conflict with vue model this.counts
         const theCounts = {}
         // initialize the counts to empty string
         for (let key in totalCounts) {
           theCounts[key] = ''
         }
-
-        // get the counts for each status
-        for (let status of statusOfCounts) {
-          // build the query for this status
-          let searchParams = new URLSearchParams(this.query)
-          if (Array.isArray(this.query)) {
-            searchParams = new URLSearchParams([...this.query, ['status', status]])
-          } else {
-            let queryStr = this.query.toString()
-            if (typeof this.query === 'object') {
-              queryStr = this.query.q.replace(':', '=')
-            }
-            searchParams = new URLSearchParams(`${queryStr}&status=${status}`)
-          }
-
-          // get the counts for this status
-          const response = await AlertsApi.getCounts(searchParams)
-
+        // get the counts for each status.
+        for (let status of statusCountsConfig) {
+          const severityCounts = await this.getCountsOfStatus(status)
           // append the counts to the count holder object
           for (let totalCountKey in totalCounts) {
             // either initialize the string or append to the string
-            if (response.severityCounts[totalCountKey]) {
-              theCounts[totalCountKey] = theCounts[totalCountKey] ? `${theCounts[totalCountKey]} / ${response.severityCounts[totalCountKey]}` : `${response.severityCounts[totalCountKey]}`
+            if (severityCounts[totalCountKey]) {
+              theCounts[totalCountKey] = theCounts[totalCountKey] ? `${theCounts[totalCountKey]} / ${severityCounts[totalCountKey]}` : `${severityCounts[totalCountKey]}`
             } else {
               theCounts[totalCountKey] = theCounts[totalCountKey] ? `${theCounts[totalCountKey]} / 0` : '0'
             }
           }
         }
-
         // append the total counts to the count holder object
-        for (let [totalCountKey, value] of Object.entries(totalCounts)) {
-          theCounts[totalCountKey] += ' / ' + value
+        for (let [key, value] of Object.entries(totalCounts)) {
+          theCounts[key] += ' / ' + value
         }
-
         // set the counts, refresh the view
         this.counts = theCounts
       } else {
-        const response = await AlertsApi.getCounts(new URLSearchParams(this.query))
-        this.counts = response.severityCounts
+        // set the counts, refresh the view
+        this.counts = totalCounts
       }
     },
     getMostSevere() {

--- a/src/components/AlertIndicator.vue
+++ b/src/components/AlertIndicator.vue
@@ -95,8 +95,11 @@ export default {
   },
   methods: {
     selectAsi() {
-      this.setFilter(this.createURLSearchParams())
+      this.setSearch(this.updateQuery())
       this.refreshList()
+    },
+    setSearch(query) {
+      this.$store.dispatch('alerts/updateQuery', query)
     },
     setFilter(filter) {
       this.$store.dispatch('alerts/setFilter', {
@@ -111,24 +114,41 @@ export default {
     severityColor(severity) {
       return this.counts && this.counts[severity] ? this.$store.getters.getConfig('colors').severity[severity] : 'transparent'
     },
-    createURLSearchParams() {
+    updateQuery() {
       const countsFilter = this.$store.getters.getConfig('countsFilter')
-      if (countsFilter) {
-        // depending on the type of query, build the search params
-        if (Array.isArray(this.query)) {
-          return new URLSearchParams([...this.query, ['status', countsFilter]])
-        } else {
-          let queryStr = this.query.toString()
-          if (typeof this.query === 'object') {
-            queryStr = this.query.q.replace(':', '=')
+      // depending on the type of query, build the search params
+      if (Array.isArray(this.query)) {
+        // reconstruct array into a single query string with boolean search terms
+        const updatedQuery = {}
+        this.query.forEach(([key, value]) => {
+          if (!updatedQuery.q) {
+            updatedQuery.q = `${key}:${value}`
+          } else {
+            updatedQuery.q = `(${updatedQuery.q}) AND ${key}:${value}`
           }
-          return new URLSearchParams(`${queryStr}&status=${countsFilter}`)
+        })
+        if (countsFilter) {
+          updatedQuery.q = `(${updatedQuery.q}) AND status:${countsFilter}`
         }
+        return updatedQuery
+      } else if (typeof this.query === 'object') {
+        // deep copy this.query
+        const updatedQuery = JSON.parse(JSON.stringify(this.query))
+        // if countsFilter is set, add it to the query and replace it in object
+        if (countsFilter) {
+          updatedQuery.q = `(${this.query.q}) AND status:${countsFilter}`
+        }
+        return updatedQuery
+      } else {
+        const updatedQuery = {q: this.query.toString()}
+        if (countsFilter) {
+          updatedQuery.q = `${this.query.toString()}&status=${countsFilter}`
+        }
+        return updatedQuery
       }
-      return new URLSearchParams(this.query)
     },
     async getCounts() {
-      const response = await AlertsApi.getCounts(this.createURLSearchParams())
+      const response = await AlertsApi.getCounts(new URLSearchParams(this.updateQuery()))
       this.counts = response.severityCounts
     },
     getMostSevere() {


### PR DESCRIPTION
Added a configuration option to display alert counts in a specific status (e.g. "open", "ack"). Clicking the panel creates a filtered query for alerts in that status. The updated query is set in the alerta panel for further modification or clearing. The complexity is that there are three different ways to define the query. An update to the previous PR https://github.com/G-Research/alerta-webui/pull/10